### PR TITLE
fix: import missing fly transition in main page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import { writable } from "svelte/store"; // For local state if needed
   import { goto } from "$app/navigation"; // Import goto for navigation
   import { BANG_COMMANDS } from "$lib/bangs.js";
-
+  
   // Güvenli metin vurgulama - XSS güvenli (innerHTML kullanmaz)
   function highlightParts(text, query) {
     if (!query || query.length < 2) return [{ text, bold: false }];
@@ -23,7 +23,7 @@
     return parts;
   }
 
-  import { fade } from "svelte/transition";
+  import { fade,fly } from "svelte/transition";
 
   // Get stores from context provided by layout
   const selectedTheme = getContext("theme"); // Read-only access is enough here


### PR DESCRIPTION
## Description
This PR fixes a `ReferenceError: fly is not defined` error on the main page (`+page.svelte`). 

## Changes
* Imported `fly` transition from `svelte/transition` in `src/routes/+page.svelte`.

## Related Issues
Fixes the runtime console error caused by missing transition imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing animation transition for the suggestions dropdown, enabling proper visual feedback when the dropdown appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->